### PR TITLE
fix(timesheet): Correct data type string for salary insert

### DIFF
--- a/timesheet.php
+++ b/timesheet.php
@@ -113,7 +113,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
             
             // **FIXED**: Use $_POST values directly as they are passed from the hidden fields
             $stmt_insert->bind_param(
-                "ssiiidddddddiddddddddddd",
+                "ssiididddddddddddddddddddd",
                 $_POST['salary_id'], $_POST['empid'], $_POST['shift_month'], $_POST['shift_year'], 
                 $_POST['days_attended'], $_POST['working_days'], $_POST['overtime'], $_POST['festival_days'], 
                 $_POST['total_shift'], $_POST['day_rate'], $_POST['hra_per_month'], $_POST['basic_per_month'], 


### PR DESCRIPTION
The save functionality in timesheet.php was failing silently because of data type mismatches in the `bind_param` function. Floats were being bound as integers and vice-versa.

This commit corrects the type definition string to match the data types of the variables being passed, ensuring that the SQL INSERT statement executes correctly.