### PR TITLE
Refactor payroll page and fix print functionality

### DIFF
--- a/payroll.php
+++ b/payroll.php
@@ -1,6 +1,7 @@
 <?php
 session_start();
 require 'db.php';
+require_once 'header.php';
 
 // Check if the user is an admin
 if (!isset($_SESSION['username']) || $_SESSION['role'] != 'admin') {
@@ -139,219 +140,208 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
 }
 ?>
 
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <title>Generate Employee Payslip</title>
-    <link rel="stylesheet" href="style.css">
-    <style>
-        .print-only { display: none; }
+<style>
+    .print-only { display: none; }
 
-        @media print {
-            body > .no-print { display: none !important; }
-            .no-print { display: none !important; }
-            .payslip-container {
-                display: block !important;
-                visibility: visible !important;
-                position: absolute;
-                left: 0;
-                top: 0;
-                width: 100%;
-                margin: 0;
-                padding: 1rem;
-                border: none;
-                box-shadow: none;
-            }
-            .screen-view { display: none !important; }
-            .print-only { display: block !important; }
-            .print-table { width: 100%; border-collapse: collapse; margin-bottom: 1rem; }
-            .print-table th, .print-table td { border: 1px solid #000; padding: 6px; text-align: left; font-size: 10px; }
-            .print-table th { background-color: #f2f2f2; font-weight: bold; }
+    @media print {
+        nav, .no-print { display: none !important; }
+        .payslip-container {
+            display: block !important;
+            visibility: visible !important;
+            position: absolute;
+            left: 0;
+            top: 0;
+            width: 100%;
+            margin: 0;
+            padding: 1rem;
+            border: none;
+            box-shadow: none;
         }
-    </style>
-</head>
-<body>
-    <div class="no-print">
-        <?php require 'header.php'; ?>
-        <div class="container">
-            <h2>Generate Employee Payslip</h2>
-            
-            <?php if ($message && !$is_editing): ?>
-                <p class="message <?php if ($is_error) echo 'error'; ?>"><?php echo htmlspecialchars($message); ?></p>
-            <?php endif; ?>
+        .screen-view { display: none !important; }
+        .print-only { display: block !important; }
+        .print-table { width: 100%; border-collapse: collapse; margin-bottom: 1rem; }
+        .print-table th, .print-table td { border: 1px solid #000; padding: 6px; text-align: left; font-size: 10px; }
+        .print-table th { background-color: #f2f2f2; font-weight: bold; }
+    }
+</style>
 
-            <form action="" method="post" class="payroll-form">
-                <div class="form-grid">
-                    <div class="form-group">
-                        <label for="empid">Select Employee:</label>
-                        <select name="empid" id="empid" required>
-                            <option value="">-- Select Employee --</option>
-                            <?php foreach ($employees as $employee): ?>
-                                <option value="<?php echo htmlspecialchars($employee['EMPID']); ?>" <?php echo (isset($form_data['empid']) && $form_data['empid'] == $employee['EMPID']) ? 'selected' : ''; ?>>
-                                    <?php echo htmlspecialchars($employee['EMPID'] . ' - ' . $employee['Name']); ?>
-                                </option>
-                            <?php endforeach; ?>
-                        </select>
-                    </div>
-                    
-                    <div class="form-group">
-                        <label for="shift_month">Select Month:</label>
-                        <select name="shift_month" id="shift_month" required>
-                            <?php for ($m = 1; $m <= 12; $m++): ?>
-                                <option value="<?php echo $m; ?>" <?php echo (isset($form_data['shift_month']) && $form_data['shift_month'] == $m) ? 'selected' : ''; ?>>
-                                    <?php echo date('F', mktime(0, 0, 0, $m, 10)); ?>
-                                </option>
-                            <?php endfor; ?>
-                        </select>
-                    </div>
+<div class="container no-print">
+    <h2>Generate Employee Payslip</h2>
 
-                    <div class="form-group">
-                        <label for="shift_year">Select Year:</label>
-                        <select name="shift_year" id="shift_year" required>
-                            <?php 
-                            $current_year = date('Y');
-                            for ($y = $current_year + 1; $y >= $current_year - 5; $y--): 
-                            ?>
-                                <option value="<?php echo $y; ?>" <?php echo (isset($form_data['shift_year']) && $form_data['shift_year'] == $y) ? 'selected' : ''; ?>>
-                                    <?php echo $y; ?>
-                                </option>
-                            <?php endfor; ?>
-                        </select>
-                    </div>
-                </div>
-                <button type="submit" name="generate_payslip">Generate Payslip</button>
-            </form>
+    <?php if ($message && !$is_editing): ?>
+        <p class="message <?php if ($is_error) echo 'error'; ?>"><?php echo htmlspecialchars($message); ?></p>
+    <?php endif; ?>
+
+    <form action="" method="post" class="payroll-form">
+        <div class="form-grid">
+            <div class="form-group">
+                <label for="empid">Select Employee:</label>
+                <select name="empid" id="empid" required>
+                    <option value="">-- Select Employee --</option>
+                    <?php foreach ($employees as $employee): ?>
+                        <option value="<?php echo htmlspecialchars($employee['EMPID']); ?>" <?php echo (isset($form_data['empid']) && $form_data['empid'] == $employee['EMPID']) ? 'selected' : ''; ?>>
+                            <?php echo htmlspecialchars($employee['EMPID'] . ' - ' . $employee['Name']); ?>
+                        </option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+
+            <div class="form-group">
+                <label for="shift_month">Select Month:</label>
+                <select name="shift_month" id="shift_month" required>
+                    <?php for ($m = 1; $m <= 12; $m++): ?>
+                        <option value="<?php echo $m; ?>" <?php echo (isset($form_data['shift_month']) && $form_data['shift_month'] == $m) ? 'selected' : ''; ?>>
+                            <?php echo date('F', mktime(0, 0, 0, $m, 10)); ?>
+                        </option>
+                    <?php endfor; ?>
+                </select>
+            </div>
+
+            <div class="form-group">
+                <label for="shift_year">Select Year:</label>
+                <select name="shift_year" id="shift_year" required>
+                    <?php
+                    $current_year = date('Y');
+                    for ($y = $current_year + 1; $y >= $current_year - 5; $y--):
+                    ?>
+                        <option value="<?php echo $y; ?>" <?php echo (isset($form_data['shift_year']) && $form_data['shift_year'] == $y) ? 'selected' : ''; ?>>
+                            <?php echo $y; ?>
+                        </option>
+                    <?php endfor; ?>
+                </select>
+            </div>
         </div>
-    </div>
+        <button type="submit" name="generate_payslip">Generate Payslip</button>
+    </form>
+</div>
 
-    <?php if ($payroll_details): ?>
-        <div class="container payslip-container">
-            <!-- Screen View -->
-            <div class="screen-view">
-                <div class="payslip-header">
-                    <h3>Payslip for <?php echo date('F Y', mktime(0,0,0,$payroll_details['Shift_Month'], 1, $payroll_details['shift_year'])); ?></h3>
-                    <div class="actions-container no-print">
-                        <button onclick="window.print()" class="print-btn">Print</button>
-                        <form action="" method="post" style="display: inline;">
-                            <input type="hidden" name="empid" value="<?php echo htmlspecialchars($payroll_details['EMPID']); ?>">
-                            <input type="hidden" name="shift_month" value="<?php echo htmlspecialchars($payroll_details['Shift_Month']); ?>">
-                            <input type="hidden" name="shift_year" value="<?php echo htmlspecialchars($payroll_details['shift_year']); ?>">
-                            <button type="submit" name="edit" class="edit-btn">Edit</button>
-                        </form>
-                         <form action="" method="post" style="display: inline;" onsubmit="return confirm('Are you sure you want to delete this payslip record?');">
-                            <input type="hidden" name="SalaryID" value="<?php echo htmlspecialchars($payroll_details['SalaryID']); ?>">
-                            <button type="submit" name="delete_payroll" class="delete-btn">Delete</button>
-                        </form>
-                    </div>
-                </div>
 
-                <?php if ($is_editing): ?>
-                    <!-- EDIT FORM -->
-                    <form action="" method="post">
-                        <input type="hidden" name="SalaryID" value="<?php echo htmlspecialchars($payroll_details['SalaryID']); ?>">
+<?php if ($payroll_details): ?>
+    <div class="container payslip-container">
+        <!-- Screen View -->
+        <div class="screen-view">
+            <div class="payslip-header">
+                <h3>Payslip for <?php echo date('F Y', mktime(0,0,0,$payroll_details['Shift_Month'], 1, $payroll_details['shift_year'])); ?></h3>
+                <div class="actions-container no-print">
+                    <button onclick="window.print()" class="print-btn">Print</button>
+                    <form action="" method="post" style="display: inline;">
                         <input type="hidden" name="empid" value="<?php echo htmlspecialchars($payroll_details['EMPID']); ?>">
                         <input type="hidden" name="shift_month" value="<?php echo htmlspecialchars($payroll_details['Shift_Month']); ?>">
                         <input type="hidden" name="shift_year" value="<?php echo htmlspecialchars($payroll_details['shift_year']); ?>">
-                        <input type="hidden" name="WorkingDays" value="<?php echo htmlspecialchars($payroll_details['WorkingDays']); ?>">
-                        
-                        <div class="edit-grid">
-                            <div class="form-group"><label>Days Worked</label><input type="number" step="0.5" name="daysWorked" value="<?php echo htmlspecialchars($payroll_details['daysWorked']); ?>"></div>
-                            <div class="form-group"><label>Overtime (Hours)</label><input type="number" step="0.5" name="OverTime" value="<?php echo htmlspecialchars($payroll_details['OverTime']); ?>"></div>
-                            <div class="form-group"><label>Festival Days</label><input type="number" step="0.5" name="FestivalDays" value="<?php echo htmlspecialchars($payroll_details['FestivalDays']); ?>"></div>
-                            <div class="form-group"><label>Advances/Deductions</label><input type="number" step="0.01" name="advances_deductions" value="<?php echo htmlspecialchars($payroll_details['advances_deductions']); ?>"></div>
-                        </div>
-                        <div class="actions-container">
-                            <button type="submit" name="update_payroll">Recalculate & Save</button>
-                            <a href="payslip.php" class="recalculate-btn">Cancel</a>
-                        </div>
+                        <button type="submit" name="edit" class="edit-btn">Edit</button>
                     </form>
-                <?php else: ?>
-                    <!-- DISPLAY VIEW -->
-                    <div class="employee-info">
-                        <div><strong>Employee ID:</strong> <?php echo htmlspecialchars($payroll_details['EMPID']); ?></div>
-                        <div><strong>Name:</strong> <?php echo htmlspecialchars($payroll_details['Name']); ?></div>
-                        <div><strong>Designation:</strong> <?php echo htmlspecialchars($payroll_details['Designation']); ?></div>
-                        <div><strong>Bank Acc No:</strong> <?php echo htmlspecialchars($payroll_details['bankAccNumber']); ?></div>
-                        <div><strong>IFSC Code:</strong> <?php echo htmlspecialchars($payroll_details['IFSC_code']); ?></div>
-                    </div>
-                    <div class="payslip-grid">
-                        <div class="workdetails">
-                            <h4>Work Details</h4>
-                            <div class="payslip-item"><span>Days Worked</span><span><?php echo htmlspecialchars($payroll_details['daysWorked']); ?></span></div>
-                            <div class="payslip-item"><span>Overtime (Hours)</span><span><?php echo htmlspecialchars($payroll_details['OverTime']); ?></span></div>
-                        </div>
-                        <div class="earnings">
-                            <h4>Earnings</h4>
-                            <div class="payslip-item"><span>Basic Wages Earned</span><span><?php echo number_format($payroll_details['BasicWages_Earned_PerMonth'], 2); ?></span></div>
-                            <div class="payslip-item"><span>HRA Earned</span><span><?php echo number_format($payroll_details['HRAEarned_PerMonth'], 2); ?></span></div>
-                            <div class="payslip-item"><span>Overtime Earnings</span><span><?php echo number_format($payroll_details['overtime_earnings'], 2); ?></span></div>
-                            <div class="payslip-item"><span>Holiday Earnings</span><span><?php echo number_format($payroll_details['National_Festival_Holidays_Earnings'], 2); ?></span></div>
-                            <div class="payslip-item total"><strong>Total Earnings</strong><strong><?php echo number_format($payroll_details['Total_Earnings'], 2); ?></strong></div>
-                        </div>
-                        <div class="deductions">
-                            <h4>Deductions</h4>
-                            <div class="payslip-item"><span>ESI (0.75%)</span><span><?php echo number_format($payroll_details['ESI_Deductions'], 2); ?></span></div>
-                            <div class="payslip-item"><span>EPF (12%)</span><span><?php echo number_format($payroll_details['EPF_deductions'], 2); ?></span></div>
-                            <div class="payslip-item"><span>Advances</span><span><?php echo htmlspecialchars($payroll_details['advances_deductions']); ?></span></div>
-                            <div class="payslip-item total"><strong>Total Deductions</strong><strong><?php echo number_format($payroll_details['Total_Deductions'], 2); ?></strong></div>
-                        </div>
-                    </div>
-                    <div class="payslip-summary">
-                        <strong>Net Payable: ₹<?php echo number_format($payroll_details['NET_Payable'], 2); ?></strong>
-                    </div>
-                <?php endif; ?>
+                     <form action="" method="post" style="display: inline;" onsubmit="return confirm('Are you sure you want to delete this payslip record?');">
+                        <input type="hidden" name="SalaryID" value="<?php echo htmlspecialchars($payroll_details['SalaryID']); ?>">
+                        <button type="submit" name="delete_payroll" class="delete-btn">Delete</button>
+                    </form>
+                </div>
             </div>
 
-            <!-- Print View (Separate Tables) -->
-            <div class="print-only">
-                <h4>Salary Details for <?php echo date('F Y', mktime(0,0,0,$payroll_details['Shift_Month'], 1, $payroll_details['shift_year'])); ?></h4>
-                <table class="print-table">
-                    <thead>
-                        <tr>
-                            <th>Name</th>
-                            <th>Salary</th>
-                            <th>Shifts</th>
-                            <th>OT Hours</th>
-                            <th>Total Shift</th>
-                            <th>Rate Per Day</th>
-                            <th>Actual Earnings</th>
-                            <th>ESI</th>
-                            <th>EPF</th>
-                            <th>Prof. Tax</th>
-                            <th>Actual Payable</th>
-                            <th>Paid (Wage Sheet)</th>
-                            <th>Advances</th>
-                            <th>Fines</th>
-                            <th>Balance to Bank</th>
-                            <th>Total Deductions</th>
-                            <th>Net Payable</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td><?php echo htmlspecialchars($payroll_details['Name']); ?></td>
-                            <td><?php echo number_format($payroll_details['salary'], 2); ?></td>
-                            <td><?php echo htmlspecialchars($payroll_details['daysWorked']); ?></td>
-                            <td><?php echo htmlspecialchars($payroll_details['OverTime']); ?></td>
-                            <td><?php echo number_format($payroll_details['Total_Shift'], 2); ?></td>
-                            <td><?php echo number_format($payroll_details['RatePerDay'], 2); ?></td>
-                            <td><?php echo number_format($payroll_details['Actual_Earnings'], 2); ?></td>
-                            <td><?php echo number_format($payroll_details['ESI_Deductions'], 2); ?></td>
-                            <td><?php echo number_format($payroll_details['EPF_deductions'], 2); ?></td>
-                            <td>0.00</td> <!-- Placeholder for Professional Tax -->
-                            <td><?php echo number_format($payroll_details['Actual_Earnings'] - $payroll_details['Total_Deductions'], 2); ?></td>
-                            <td><?php echo number_format($payroll_details['NET_Payable'], 2); ?></td>
-                            <td><?php echo number_format($payroll_details['advances_deductions'], 2); ?></td>
-                            <td>0.00</td> <!-- Placeholder for Fines -->
-                            <td><?php echo number_format($payroll_details['Actual_Paid'], 2); ?></td>
-                            <td><?php echo number_format($payroll_details['Total_Deductions'], 2); ?></td>
-                            <td><?php echo number_format($payroll_details['NET_Payable'], 2); ?></td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
+            <?php if ($is_editing): ?>
+                <!-- EDIT FORM -->
+                <form action="" method="post">
+                    <input type="hidden" name="SalaryID" value="<?php echo htmlspecialchars($payroll_details['SalaryID']); ?>">
+                    <input type="hidden" name="empid" value="<?php echo htmlspecialchars($payroll_details['EMPID']); ?>">
+                    <input type="hidden" name="shift_month" value="<?php echo htmlspecialchars($payroll_details['Shift_Month']); ?>">
+                    <input type="hidden" name="shift_year" value="<?php echo htmlspecialchars($payroll_details['shift_year']); ?>">
+                    <input type="hidden" name="WorkingDays" value="<?php echo htmlspecialchars($payroll_details['WorkingDays']); ?>">
+
+                    <div class="edit-grid">
+                        <div class="form-group"><label>Days Worked</label><input type="number" step="0.5" name="daysWorked" value="<?php echo htmlspecialchars($payroll_details['daysWorked']); ?>"></div>
+                        <div class="form-group"><label>Overtime (Hours)</label><input type="number" step="0.5" name="OverTime" value="<?php echo htmlspecialchars($payroll_details['OverTime']); ?>"></div>
+                        <div class="form-group"><label>Festival Days</label><input type="number" step="0.5" name="FestivalDays" value="<?php echo htmlspecialchars($payroll_details['FestivalDays']); ?>"></div>
+                        <div class="form-group"><label>Advances/Deductions</label><input type="number" step="0.01" name="advances_deductions" value="<?php echo htmlspecialchars($payroll_details['advances_deductions']); ?>"></div>
+                    </div>
+                    <div class="actions-container">
+                        <button type="submit" name="update_payroll">Recalculate & Save</button>
+                        <a href="payslip.php" class="recalculate-btn">Cancel</a>
+                    </div>
+                </form>
+            <?php else: ?>
+                <!-- DISPLAY VIEW -->
+                <div class="employee-info">
+                    <div><strong>Employee ID:</strong> <?php echo htmlspecialchars($payroll_details['EMPID']); ?></div>
+                    <div><strong>Name:</strong> <?php echo htmlspecialchars($payroll_details['Name']); ?></div>
+                    <div><strong>Designation:</strong> <?php echo htmlspecialchars($payroll_details['Designation']); ?></div>
+                    <div><strong>Bank Acc No:</strong> <?php echo htmlspecialchars($payroll_details['bankAccNumber']); ?></div>
+                    <div><strong>IFSC Code:</strong> <?php echo htmlspecialchars($payroll_details['IFSC_code']); ?></div>
+                </div>
+                <div class="payslip-grid">
+                    <div class="workdetails">
+                        <h4>Work Details</h4>
+                        <div class="payslip-item"><span>Days Worked</span><span><?php echo htmlspecialchars($payroll_details['daysWorked']); ?></span></div>
+                        <div class="payslip-item"><span>Overtime (Hours)</span><span><?php echo htmlspecialchars($payroll_details['OverTime']); ?></span></div>
+                    </div>
+                    <div class="earnings">
+                        <h4>Earnings</h4>
+                        <div class="payslip-item"><span>Basic Wages Earned</span><span><?php echo number_format($payroll_details['BasicWages_Earned_PerMonth'], 2); ?></span></div>
+                        <div class="payslip-item"><span>HRA Earned</span><span><?php echo number_format($payroll_details['HRAEarned_PerMonth'], 2); ?></span></div>
+                        <div class="payslip-item"><span>Overtime Earnings</span><span><?php echo number_format($payroll_details['overtime_earnings'], 2); ?></span></div>
+                        <div class="payslip-item"><span>Holiday Earnings</span><span><?php echo number_format($payroll_details['National_Festival_Holidays_Earnings'], 2); ?></span></div>
+                        <div class="payslip-item total"><strong>Total Earnings</strong><strong><?php echo number_format($payroll_details['Total_Earnings'], 2); ?></strong></div>
+                    </div>
+                    <div class="deductions">
+                        <h4>Deductions</h4>
+                        <div class="payslip-item"><span>ESI (0.75%)</span><span><?php echo number_format($payroll_details['ESI_Deductions'], 2); ?></span></div>
+                        <div class="payslip-item"><span>EPF (12%)</span><span><?php echo number_format($payroll_details['EPF_deductions'], 2); ?></span></div>
+                        <div class="payslip-item"><span>Advances</span><span><?php echo htmlspecialchars($payroll_details['advances_deductions']); ?></span></div>
+                        <div class="payslip-item total"><strong>Total Deductions</strong><strong><?php echo number_format($payroll_details['Total_Deductions'], 2); ?></strong></div>
+                    </div>
+                </div>
+                <div class="payslip-summary">
+                    <strong>Net Payable: ₹<?php echo number_format($payroll_details['NET_Payable'], 2); ?></strong>
+                </div>
+            <?php endif; ?>
         </div>
-    <?php endif; ?>
-</body>
-</html>
+
+        <!-- Print View (Separate Tables) -->
+        <div class="print-only">
+            <h4>Salary Details for <?php echo date('F Y', mktime(0,0,0,$payroll_details['Shift_Month'], 1, $payroll_details['shift_year'])); ?></h4>
+            <table class="print-table">
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Salary</th>
+                        <th>Shifts</th>
+                        <th>OT Hours</th>
+                        <th>Total Shift</th>
+                        <th>Rate Per Day</th>
+                        <th>Actual Earnings</th>
+                        <th>ESI</th>
+                        <th>EPF</th>
+                        <th>Prof. Tax</th>
+                        <th>Actual Payable</th>
+                        <th>Paid (Wage Sheet)</th>
+                        <th>Advances</th>
+                        <th>Fines</th>
+                        <th>Balance to Bank</th>
+                        <th>Total Deductions</th>
+                        <th>Net Payable</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td><?php echo htmlspecialchars($payroll_details['Name']); ?></td>
+                        <td><?php echo number_format($payroll_details['salary'], 2); ?></td>
+                        <td><?php echo htmlspecialchars($payroll_details['daysWorked']); ?></td>
+                        <td><?php echo htmlspecialchars($payroll_details['OverTime']); ?></td>
+                        <td><?php echo number_format($payroll_details['Total_Shift'], 2); ?></td>
+                        <td><?php echo number_format($payroll_details['RatePerDay'], 2); ?></td>
+                        <td><?php echo number_format($payroll_details['Actual_Earnings'], 2); ?></td>
+                        <td><?php echo number_format($payroll_details['ESI_Deductions'], 2); ?></td>
+                        <td><?php echo number_format($payroll_details['EPF_deductions'], 2); ?></td>
+                        <td>0.00</td> <!-- Placeholder for Professional Tax -->
+                        <td><?php echo number_format($payroll_details['Actual_Earnings'] - $payroll_details['Total_Deductions'], 2); ?></td>
+                        <td><?php echo number_format($payroll_details['NET_Payable'], 2); ?></td>
+                        <td><?php echo number_format($payroll_details['advances_deductions'], 2); ?></td>
+                        <td>0.00</td> <!-- Placeholder for Fines -->
+                        <td><?php echo number_format($payroll_details['Actual_Paid'], 2); ?></td>
+                        <td><?php echo number_format($payroll_details['Total_Deductions'], 2); ?></td>
+                        <td><?php echo number_format($payroll_details['NET_Payable'], 2); ?></td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+<?php endif; ?>
+<?php require_once 'footer.php'; ?>


### PR DESCRIPTION
The payroll page was printing a blank page. This was likely due to an invalid HTML structure, as the page contained its own HTML boilerplate while also including a header file that likely did the same.

This change refactors `payroll.php` to use the standard site-wide header and footer. It removes the local HTML, head, and body tags and includes `header.php` and `footer.php`.

The print-specific CSS has been updated to hide the navigation bar and the payslip generation form, ensuring only the payslip itself is sent to the printer.